### PR TITLE
add option to not use sudo (for certain embedded OSes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default-target = "armv7-unknown-linux-gnueabihf"
 
 [features]
 default = []
+no-sudo = []
 
 # Not needed for now, serde feature works implicitly...
 #[namespaced-features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,12 +80,29 @@ impl ThrottledStatus {
 }
 
 /// Execute the given command and capture its std_output without modifying it
+#[cfg(not(feature = "no-sudo"))]
 pub fn exec_command(command: Cmd, src: Option<Src>) -> Result<String, PopenError> {
     // "vcgencmd" must be in PATH
     const VCGENCMD_INVOCATION: &str = "vcgencmd";
 
     let vcgencmd_output = Exec::cmd("sudo")
         .arg(VCGENCMD_INVOCATION)
+        .arg(resolve_command(command))
+        .arg(resolve_src(src).unwrap_or_default())
+        .stdout(Redirection::Pipe)
+        .capture()?
+        .stdout_str();
+
+    Ok(vcgencmd_output)
+}
+
+/// Execute the given command and capture its std_output without modifying it
+#[cfg(feature = "no-sudo")]
+pub fn exec_command(command: Cmd, src: Option<Src>) -> Result<String, PopenError> {
+    // "vcgencmd" must be in PATH
+    const VCGENCMD_INVOCATION: &str = "vcgencmd";
+
+    let vcgencmd_output = Exec::cmd(VCGENCMD_INVOCATION)
         .arg(resolve_command(command))
         .arg(resolve_src(src).unwrap_or_default())
         .stdout(Redirection::Pipe)


### PR DESCRIPTION
Hi, I needed this change to allow me to use your crate in a robotics project. I'm using buildroot, which does not use sudo.